### PR TITLE
Addition of "bundleOptions": "None" to package manifests

### DIFF
--- a/Umbraco Tag Manager/App_Plugins/TagList/package.manifest
+++ b/Umbraco Tag Manager/App_Plugins/TagList/package.manifest
@@ -1,52 +1,53 @@
 {
-  "propertyEditors": [
-    {
-      "alias": "CommonTagList",
-      "name": "Common Tags",
-      "icon": "icon-list",
-      "group": "pickers",
-      "editor": {
-        "view": "~/App_Plugins/TagList/taglisteditor.html",
-        "valueType": "JSON"
-      },
-      "prevalues": {
-        "fields": [
-          {
-            "label": "Number of Tags",
-            "description": "The number of tags to show in the dropdown",
-            "key": "maxTags",
-            "view": "number",
-            "validation": [
-              {
-                "type": "Required"
-              }
-            ]
-          },
-          {
-            "label": "Tag Control",
-            "description": "Alias of the TAG list to associate",
-            "key": "tagParent",
-            "view": "textstring",
-            "validation": [
-              {
-                "type": "Required"
-              }
-            ]
-          },
-          {
-            "label": "Group override",
-            "description": "If the value is blank it will use the group defined on the pages TAG control",
-            "key": "groupOverride",
-            "view": "textstring"
-          }
-        ]
-      },
-      "defaultConfig": { "maxTags": "10" }
-    }
-  ],
-  // array of files we want to inject into the application on app_start
-  "javascript": [
-    "~/App_Plugins/TagList/taglisteditor.controller.js",
-    "~/App_Plugins/TagList/taglist.resource.js"
-  ]
+    "propertyEditors": [
+        {
+            "alias": "CommonTagList",
+            "name": "Common Tags",
+            "icon": "icon-list",
+            "group": "pickers",
+            "editor": {
+                "view": "~/App_Plugins/TagList/taglisteditor.html",
+                "valueType": "JSON"
+            },
+            "prevalues": {
+                "fields": [
+                    {
+                        "label": "Number of Tags",
+                        "description": "The number of tags to show in the dropdown",
+                        "key": "maxTags",
+                        "view": "number",
+                        "validation": [
+                            {
+                                "type": "Required"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "Tag Control",
+                        "description": "Alias of the TAG list to associate",
+                        "key": "tagParent",
+                        "view": "textstring",
+                        "validation": [
+                            {
+                                "type": "Required"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "Group override",
+                        "description": "If the value is blank it will use the group defined on the pages TAG control",
+                        "key": "groupOverride",
+                        "view": "textstring"
+                    }
+                ]
+            },
+            "defaultConfig": { "maxTags": "10" }
+        }
+    ],
+    // array of files we want to inject into the application on app_start
+    "javascript": [
+        "~/App_Plugins/TagList/taglisteditor.controller.js",
+        "~/App_Plugins/TagList/taglist.resource.js"
+    ],
+    "bundleOptions": "None"
 }

--- a/Umbraco Tag Manager/App_Plugins/TagManager/package.manifest
+++ b/Umbraco Tag Manager/App_Plugins/TagManager/package.manifest
@@ -1,13 +1,14 @@
 {
-  "dashboards": [
-    {
-      "alias": "tagManager",
-      "view": "~/App_Plugins/TagManager/Dashboard.html",
-      "sections": [ "TagManager" ]
-    }
-  ],
-	"javascript": [
-	    "~/App_Plugins/TagManager/backoffice/TagManagerTree/TagManager.controller.js?v=10",
-	    "~/App_Plugins/TagManager/TagManager.resource.js"
-	]
+    "dashboards": [
+        {
+            "alias": "tagManager",
+            "view": "~/App_Plugins/TagManager/Dashboard.html",
+            "sections": [ "TagManager" ]
+        }
+    ],
+    "javascript": [
+        "~/App_Plugins/TagManager/backoffice/TagManagerTree/TagManager.controller.js?v=10",
+        "~/App_Plugins/TagManager/TagManager.resource.js"
+    ],
+    "bundleOptions": "None"
 }

--- a/Umbraco Tag Manager/Umbraco.Community.TagManager.csproj
+++ b/Umbraco Tag Manager/Umbraco.Community.TagManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>10.0.0-rc2</Version>
+    <Version>10.0.0-rc6</Version>
     <ContentTargetFolders>.</ContentTargetFolders>
     <Product>Umbraco.Community.TagManager</Product>
     <PackageId>Umbraco.Community.TagManager</PackageId>


### PR DESCRIPTION
Something in the front-end JS files is breaking parts of the Umbraco back-office when running in non-Debug mode. My JS skills and familiarity with the codebase are such that I am currently unable to attempt to resolve the underlying issue, however, this addition removes the files from back-office bundling, so they do not break other back-office functionality, even with the JS issues.

Ideally, someone would resolve the JS problems, but if that isn't forthcoming, this is a work-around.