### PR TITLE
Updated Dependencies to support Umbraco 13.x.x

### DIFF
--- a/Umbraco Tag Manager/Umbraco.Community.TagManager.csproj
+++ b/Umbraco Tag Manager/Umbraco.Community.TagManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>10.0.0-rc6</Version>
+    <Version>10.0.0-rc7</Version>
     <ContentTargetFolders>.</ContentTargetFolders>
     <Product>Umbraco.Community.TagManager</Product>
     <PackageId>Umbraco.Community.TagManager</PackageId>
@@ -18,9 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Umbraco.Cms.Core" Version="[10.0.1, 11.0.0]" />
-	  <PackageReference Include="Umbraco.Cms.Web.Website" Version="[10.0.1, 11.0.0]" PrivateAssets="All" />
-	  <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="[10.0.1, 11.0.0]" PrivateAssets="All" />
+	  <PackageReference Include="Umbraco.Cms.Core" Version="[10.0.1, 14.0.0)" />
+	  <PackageReference Include="Umbraco.Cms.Web.Website" Version="[10.0.1, 14.0.0)" PrivateAssets="All" />
+	  <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="[10.0.1, 14.0.0)" PrivateAssets="All" />
   </ItemGroup>
 
 	<Import Project="..\Custom.targets" />


### PR DESCRIPTION
I was getting upgrade/build warnings due to the listed supported Umbraco CMS dependency being too low. This packages does work in Umbraco 13, so I have updated the csproj file to reflect that:

![image](https://github.com/user-attachments/assets/0bd9751f-09ff-47c2-a050-265980c17384)

Ref: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges
